### PR TITLE
Custom calendar labels

### DIFF
--- a/backend/database/models/users.js
+++ b/backend/database/models/users.js
@@ -29,7 +29,10 @@ const userSchema = new mongoose.Schema({
     },
   ],
   calendarNotes: mongoose.Schema.Types.Mixed,
-  customLabels: Array,
+  customLabels: [{
+    text: String,
+    color: String,
+  }],
 });
 
 const USERS = mongoose.model('Users', userSchema);

--- a/frontend/api/calendar.js
+++ b/frontend/api/calendar.js
@@ -40,7 +40,8 @@ function getCalendarLabels() {
 
 /**
  * Adds a custom label for Calendar events.
- * @param { string } text The user-defined label text.
+ * @param { string } text The user-defined label text. If there is already a
+ *        label with the same text, it will be updated.
  * @param { string } color The color of the dot on the Calendar GUI that will
  *        represent this label.
  * @returns { Promise } A Promise that resolves when the label was successfully

--- a/frontend/api/calendar.js
+++ b/frontend/api/calendar.js
@@ -30,8 +30,39 @@ function removeCalendarNote(when, noteObj) {
   return authFetch(`${SERVER_ADDR}/mycalendar/notes`, 'DELETE', { [when]: noteObj });
 }
 
+/**
+ * Gets all custom user-defined labels for Calendar events.
+ * @returns { Promise } A Promise that resolves to an array of objects, each with
+ * a `text` and a `color` property. */
+function getCalendarLabels() {
+  return authFetch(`${SERVER_ADDR}/mycalendar/labels`, 'GET');
+}
+
+/**
+ * Adds a custom label for Calendar events.
+ * @param { string } text The user-defined label text.
+ * @param { string } color The color of the dot on the Calendar GUI that will
+ *        represent this label.
+ * @returns { Promise } A Promise that resolves when the label was successfully
+ * added or updated. */
+function addCalendarLabel(text, color) {
+  return authFetch(`${SERVER_ADDR}/mycalendar/labels`, 'PUT', { text, color });
+}
+
+/**
+ * Removes a custom Calendar label.
+ * @param { string } text The text of the label to remove.
+ * @returns { Promise } A Promise that resolves to `true` if the label was found and
+ *          removed. `False` indicates that the label was not found. */
+function removeCalendarLabel(text) {
+  return authFetch(`${SERVER_ADDR}/mycalendar/labels`, 'DELETE', { text });
+}
+
 module.exports = {
   getCalendarNotes,
   addCalendarNote,
   removeCalendarNote,
+  getCalendarLabels,
+  addCalendarLabel,
+  removeCalendarLabel,
 };

--- a/frontend/api/tests/calendar.test.js
+++ b/frontend/api/tests/calendar.test.js
@@ -2,6 +2,9 @@ const {
   getCalendarNotes,
   addCalendarNote,
   removeCalendarNote,
+  getCalendarLabels,
+  addCalendarLabel,
+  removeCalendarLabel,
 } = require('../calendar');
 const { registerAndLogin } = require('./testutil');
 
@@ -173,6 +176,129 @@ it('Removing a note that does not exist has no effect', (done) => {
               dots: 'green',
             }],
           });
+          done();
+        })
+        .catch((error) => {
+          done(error);
+        });
+    })
+    .catch((error) => {
+      done(error);
+    });
+});
+
+it('Custom labels are empty by default', () => {
+  expect(getCalendarLabels()).resolves.toStrictEqual([]);
+});
+
+it('Can add custom labels', (done) => {
+  addCalendarLabel('My First Label', 'red')
+    .then(() => {
+      expect(getCalendarLabels()).resolves.toStrictEqual([{
+        text: 'My First Label',
+        color: 'red',
+      }]);
+      done();
+    })
+    .catch((error) => {
+      done(error);
+    });
+});
+
+it('Can add multiple custom labels', (done) => {
+  addCalendarLabel('My First Label', 'red')
+    .then(() => {
+      addCalendarLabel('My Second Label', 'green')
+        .then(() => {
+          getCalendarLabels()
+            .then((labels) => {
+              expect(labels.sort()).toStrictEqual([{
+                text: 'My First Label',
+                color: 'red',
+              },
+              {
+                text: 'My Second Label',
+                color: 'green',
+              }].sort());
+              done();
+            })
+            .catch((error) => {
+              done(error);
+            });
+        })
+        .catch((error) => {
+          done(error);
+        });
+    })
+    .catch((error) => {
+      done(error);
+    });
+});
+
+it('Can remove custom labels', (done) => {
+  addCalendarLabel('My First Label', 'red')
+    .then(() => {
+      addCalendarLabel('My Second Label', 'green')
+        .then(() => {
+          removeCalendarLabel('My Second Label')
+            .then((status) => {
+              expect(status).toBe(true);
+
+              // Check that the label was removed
+              expect(getCalendarLabels()).resolves.toStrictEqual([{
+                text: 'My First Label',
+                color: 'red',
+              }]);
+              done();
+            })
+            .catch((error) => {
+              done(error);
+            });
+        })
+        .catch((error) => {
+          done(error);
+        });
+    })
+    .catch((error) => {
+      done(error);
+    });
+});
+
+it('Remove non existing custom label works', (done) => {
+  addCalendarLabel('My First Label', 'red')
+    .then(() => {
+      removeCalendarLabel('Fake Label')
+        .then((status) => {
+          expect(status).toBe(false);
+
+          // Check that other labels were not affected
+          expect(getCalendarLabels()).resolves.toStrictEqual([{
+            text: 'My First Label',
+            color: 'red',
+          }]);
+          done();
+        })
+        .catch((error) => {
+          done(error);
+        });
+    })
+    .catch((error) => {
+      done(error);
+    });
+});
+
+it('Can update existing custom label', (done) => {
+  // Add a red label
+  addCalendarLabel('My First Label', 'red')
+    .then(() => {
+      // Now change it to blue
+      addCalendarLabel('My First Label', 'blue')
+        .then(() => {
+          // Check that the label was updated to blue
+          expect(getCalendarLabels()).resolves.toStrictEqual([{
+            text: 'My First Label',
+            color: 'blue',
+          }]);
           done();
         })
         .catch((error) => {


### PR DESCRIPTION
Adds `getCalendarLabels`, `addCalendarLabel`, and `removeCalendarLabel` functions to the frontend/api/calendar API, and adds supporting backend code and tests. This will allow the user to supply custom labels to events on the Calendar.