### PR TITLE
Allow the user to upload multiple images per plant

### DIFF
--- a/backend/database/models/users.js
+++ b/backend/database/models/users.js
@@ -22,10 +22,11 @@ const userSchema = new mongoose.Schema({
       plantID: String,
       name: String,
       location: String,
-      image: {
+      images: [{
+        date: Date,
         sourceURL: String,
         base64: String,
-      },
+      }],
     },
   ],
   calendarNotes: mongoose.Schema.Types.Mixed,

--- a/backend/database/models/users.js
+++ b/backend/database/models/users.js
@@ -24,7 +24,6 @@ const userSchema = new mongoose.Schema({
       location: String,
       images: [{
         date: Date,
-        sourceURL: String,
         base64: String,
       }],
     },

--- a/backend/routes/myplants.js
+++ b/backend/routes/myplants.js
@@ -26,6 +26,9 @@ function rewritePlantForRequest(plant, req) {
       ret.images[i].sourceURL = `${req.protocol}://${req.get('host')}/myplants/${ret[idProp]}/image/${i}`;
       ret.images[i].authenticationRequired = true;
     }
+
+    // Remove the _id property
+    delete ret.images[i][idProp];
   }
 
   // Rename '_id' to 'instanceID'

--- a/backend/routes/myplants.js
+++ b/backend/routes/myplants.js
@@ -66,7 +66,7 @@ module.exports = (app) => {
 
   authPost(app, '/myplants/:instanceID/image/', (req, res, userDoc) => {
     const { instanceID } = req.params;
-    const { base64, date } = req.body.image;
+    const { base64, date } = req.body;
     let myPlantsByID = [];
     if (userDoc.myPlantsByID) {
       myPlantsByID = userDoc.myPlantsByID;
@@ -95,7 +95,7 @@ module.exports = (app) => {
 
   authPut(app, '/myplants/:instanceID/image/:index', (req, res, userDoc) => {
     const { instanceID, index } = req.params;
-    const { base64, date } = req.body.image;
+    const { base64, date } = req.body;
     let myPlantsByID = [];
     if (userDoc.myPlantsByID) {
       myPlantsByID = userDoc.myPlantsByID;

--- a/backend/routes/myplants.js
+++ b/backend/routes/myplants.js
@@ -10,7 +10,7 @@ const { findOneDocument } = require('../database/findDocuments');
 /**
  * Rewrites a Plant object so it is readable by the client. This involves renaming the
  * `_id` property to `instanceID`, and changing base64 images to a URL instead (so we
- * don't waste bandwidth sending the image when it may not be needed).
+ * don't waste bandwidth sending the images when they may not be needed).
  * @param {*} plant The raw owned Plant instance, directly from the database.
  * @param {*} req The Request object.
  * @returns {*} The plant, but in a format that is expected by the client.
@@ -18,11 +18,14 @@ const { findOneDocument } = require('../database/findDocuments');
 function rewritePlantForRequest(plant, req) {
   const ret = plant;
   const idProp = '_id';
-  if (ret.image.base64) {
-    // Rewrite plant to refer to server image URL instead of sending the whole image now
-    delete ret.image.base64;
-    ret.image.sourceURL = `${req.protocol}://${req.get('host')}/myplants/${ret[idProp]}/image.jpg`;
-    ret.image.authenticationRequired = true;
+
+  for (let i = 0; i < ret.images.length; i += 1) {
+    if (ret.images[i].base64) {
+      // Rewrite plant to refer to server image URL instead of sending the whole image now
+      delete ret.images[i].base64;
+      ret.images[i].sourceURL = `${req.protocol}://${req.get('host')}/myplants/${ret[idProp]}/image/${i}`;
+      ret.images[i].authenticationRequired = true;
+    }
   }
 
   // Rename '_id' to 'instanceID'
@@ -42,8 +45,8 @@ module.exports = (app) => {
     res.json(myPlantsByID.map((rawPlant) => rewritePlantForRequest(rawPlant, req)));
   }, true);
 
-  authGet(app, '/myplants/:instanceID/image.jpg', (req, res, userDoc) => {
-    const { instanceID } = req.params;
+  authGet(app, '/myplants/:instanceID/image/:index', (req, res, userDoc) => {
+    const { instanceID, index } = req.params;
     let myPlantsByID = [];
     if (userDoc.myPlantsByID) {
       myPlantsByID = userDoc.myPlantsByID;
@@ -51,26 +54,58 @@ module.exports = (app) => {
 
     const idProp = '_id';
     const plant = myPlantsByID.find((cur) => cur[idProp].toString() === instanceID.toString());
-    if (plant && plant.image.base64) {
-      res.json(plant.image.base64);
+    if (plant && index >= 0 && index < plant.images.length && plant.images[index].base64) {
+      res.json(plant.images[index].base64);
     } else {
       res.status(404).send();
     }
   }, true);
 
-  authPut(app, '/myplants/:instanceID/image.jpg', (req, res, userDoc) => {
+  authPost(app, '/myplants/:instanceID/image/', (req, res, userDoc) => {
     const { instanceID } = req.params;
-    const { base64 } = req.body.image;
+    const { base64, date } = req.body.image;
     let myPlantsByID = [];
     if (userDoc.myPlantsByID) {
       myPlantsByID = userDoc.myPlantsByID;
     }
 
     const idProp = '_id';
-    const idx = myPlantsByID.findIndex((cur) => cur[idProp].toString() === instanceID.toString());
-    if (idx !== -1) {
-      myPlantsByID[idx].image = {
+    const plantIdx = myPlantsByID.findIndex(
+      (cur) => cur[idProp].toString() === instanceID.toString(),
+    );
+    if (plantIdx !== -1) {
+      myPlantsByID[plantIdx].images.push({
         base64,
+        date,
+      });
+
+      updateUserDocument(userDoc.userId, { myPlantsByID }).then(() => {
+        res.status(201).json({});
+      }).catch((saveError) => {
+        console.error(`Failed to update a plant picture for user ID ${userDoc.userId}. Reason: ${saveError}`);
+        res.status(500).json({});
+      });
+    } else {
+      res.status(404).send();
+    }
+  }, true);
+
+  authPut(app, '/myplants/:instanceID/image/:index', (req, res, userDoc) => {
+    const { instanceID, index } = req.params;
+    const { base64, date } = req.body.image;
+    let myPlantsByID = [];
+    if (userDoc.myPlantsByID) {
+      myPlantsByID = userDoc.myPlantsByID;
+    }
+
+    const idProp = '_id';
+    const plantIdx = myPlantsByID.findIndex(
+      (cur) => cur[idProp].toString() === instanceID.toString(),
+    );
+    if (plantIdx !== -1 && index >= 0 && index < myPlantsByID[plantIdx].images.length) {
+      myPlantsByID[plantIdx].images[index] = {
+        base64,
+        date,
       };
 
       updateUserDocument(userDoc.userId, { myPlantsByID }).then(() => {
@@ -84,12 +119,37 @@ module.exports = (app) => {
     }
   }, true);
 
+  authDelete(app, '/myplants/:instanceID/image/:index', (req, res, userDoc) => {
+    const { instanceID, index } = req.params;
+    let myPlantsByID = [];
+    if (userDoc.myPlantsByID) {
+      myPlantsByID = userDoc.myPlantsByID;
+    }
+
+    const idProp = '_id';
+    const plantIdx = myPlantsByID.findIndex(
+      (cur) => cur[idProp].toString() === instanceID.toString(),
+    );
+    if (plantIdx !== -1 && index >= 0 && index < myPlantsByID[plantIdx].images.length) {
+      myPlantsByID[plantIdx].images.splice(index, 1);
+
+      updateUserDocument(userDoc.userId, { myPlantsByID }).then(() => {
+        res.status(200).json({});
+      }).catch((saveError) => {
+        console.error(`Failed to delete a plant picture for user ID ${userDoc.userId}. Reason: ${saveError}`);
+        res.status(500).json({});
+      });
+    } else {
+      res.status(404).send();
+    }
+  }, true);
+
   authPost(app, '/myplants', (req, res, userDoc) => {
     const {
       plantID,
       name,
       location,
-      image,
+      images,
     } = req.body;
     let myPlantsByID = [];
     if (userDoc.myPlantsByID) {
@@ -101,7 +161,7 @@ module.exports = (app) => {
       plantID,
       name,
       location,
-      image,
+      images,
     };
     myPlantsByID.push(plant);
 
@@ -167,9 +227,6 @@ module.exports = (app) => {
       }
       if (newPlantProps.location) {
         myPlantsByID[plantIndex].location = newPlantProps.location;
-      }
-      if (newPlantProps.image) {
-        myPlantsByID[plantIndex].image = newPlantProps.image;
       }
 
       updateUserDocument(userDoc.userId, { myPlantsByID }).then(() => {

--- a/backend/routes/myplants.js
+++ b/backend/routes/myplants.js
@@ -83,7 +83,8 @@ module.exports = (app) => {
       });
 
       updateUserDocument(userDoc.userId, { myPlantsByID }).then(() => {
-        res.status(201).json({});
+        // Return the index of the new image
+        res.status(201).json(myPlantsByID[plantIdx].images.length - 1);
       }).catch((saveError) => {
         console.error(`Failed to update a plant picture for user ID ${userDoc.userId}. Reason: ${saveError}`);
         res.status(500).json({});

--- a/frontend/api/myplants.js
+++ b/frontend/api/myplants.js
@@ -185,7 +185,8 @@ function updateMyPlant(instanceID, plant) {
  * @param {string} instanceID The instance ID of the owned plant.
  * @param {string} base64 The base64-encoded JPEG data of the image to upload.
  * @param {Date} date The date when the picture was taken.
- * @returns {Promise} A Promise that resolves after the image has been uploaded. */
+ * @returns {Promise<Number>} A Promise that resolves after the image has been uploaded.
+ * The resolved value is the zero-based index of the image on the plant. */
 function addMyPlantImage(instanceID, base64, date) {
   return new Promise((added, rejected) => {
     if (!instanceID) {
@@ -198,8 +199,8 @@ function addMyPlantImage(instanceID, base64, date) {
       authFetch(`${SERVER_ADDR}/myplants/${instanceID}/image/`, 'POST', {
         base64, date,
       })
-        .then(() => {
-          added();
+        .then((res) => {
+          added(res);
         })
         .catch((error) => {
           rejected(error);

--- a/frontend/api/plants.js
+++ b/frontend/api/plants.js
@@ -10,6 +10,16 @@ function getPlants() {
   return authFetch(`${SERVER_ADDR}/plants/`);
 }
 
+/**
+ * Gets the information about a plant.
+ * @param {String} plantID The ID of the plant.
+ * @returns {Promise} A Promise that resolves to an object containing
+ * information about the plant. */
+function getPlantInfo(plantID) {
+  return authFetch(`${SERVER_ADDR}/plants/${plantID}`);
+}
+
 module.exports = {
   getPlants,
+  getPlantInfo,
 };

--- a/frontend/api/tests/myplants.test.js
+++ b/frontend/api/tests/myplants.test.js
@@ -282,7 +282,103 @@ it('Can update multiple plant properties simultaneously', (done) => {
     });
 });
 
-//TODO: Test multiple plant images and removing plant images
+it('Can assign multiple plant images', (done) => {
+  // Add the plant
+  const when = '2020-12-06T07:19:48.680Z';
+  const newWhen = '2020-12-07T07:19:48.680Z';
+  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ base64: 'SGVsbG8=', date: when }])
+    .then((instanceID) => {
+      expect(instanceID).toBeTruthy();
+
+      // Add another image for the plant
+      addMyPlantImage(instanceID, 'd29ybGQ=', newWhen)
+        .then((newImageIndex) => {
+          expect(newImageIndex).toBe(1);
+          // Ensure that it is now updated in 'myplants'
+          getMyPlants()
+            .then((myPlants) => {
+              expect(myPlants).toBeTruthy();
+              expect(myPlants).toHaveLength(1);
+
+              const newPlantState = myPlants.find((cur) => cur.instanceID === instanceID);
+              expect(newPlantState.images).toHaveLength(2);
+
+              // And ensure that we can both images via an authFetch
+              // Fetch the first image
+              authFetch(newPlantState.images[0].sourceURL)
+                .then((image0Response) => {
+                  expect(image0Response).toStrictEqual('SGVsbG8=');
+
+                  // Fetch the second image
+                  authFetch(newPlantState.images[1].sourceURL)
+                    .then((image1Response) => {
+                      expect(image1Response).toStrictEqual('d29ybGQ=');
+                      done();
+                    })
+                    .catch((error) => {
+                      done(error);
+                    });
+                })
+                .catch((error) => {
+                  done(error);
+                });
+            });
+        })
+        .catch((error) => {
+          done(error);
+        });
+    })
+    .catch((error) => {
+      done(error);
+    });
+});
+
+it('Can remove plant images', (done) => {
+  // Add the plant
+  const when = '2020-12-06T07:19:48.680Z';
+  const newWhen = '2020-12-07T07:19:48.680Z';
+  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ base64: 'SGVsbG8=', date: when }])
+    .then((instanceID) => {
+      expect(instanceID).toBeTruthy();
+
+      // Add another image for the plant
+      addMyPlantImage(instanceID, 'd29ybGQ=', newWhen)
+        .then(() => {
+          // Remove the first image
+          removeMyPlantImage(instanceID, 0)
+            .then(() => {
+              // Ensure that it is now updated in 'myplants'
+              getMyPlants()
+                .then((myPlants) => {
+                  expect(myPlants).toBeTruthy();
+                  expect(myPlants).toHaveLength(1);
+
+                  const newPlantState = myPlants.find((cur) => cur.instanceID === instanceID);
+                  expect(newPlantState.images).toHaveLength(1);
+
+                  // Ensure that we can still fetch the remaining image
+                  authFetch(newPlantState.images[0].sourceURL)
+                    .then((image0Response) => {
+                      expect(image0Response).toStrictEqual('d29ybGQ=');
+                      done();
+                    })
+                    .catch((error) => {
+                      done(error);
+                    });
+                });
+            })
+            .catch((error) => {
+              done(error);
+            });
+        })
+        .catch((error) => {
+          done(error);
+        });
+    })
+    .catch((error) => {
+      done(error);
+    });
+});
 
 it('Can update plant image by base64', (done) => {
   // Add the plant

--- a/frontend/api/tests/myplants.test.js
+++ b/frontend/api/tests/myplants.test.js
@@ -2,6 +2,9 @@ const {
   getMyPlants,
   addToMyPlants,
   removeFromMyPlants,
+  updateMyPlantImage,
+  addMyPlantImage,
+  removeMyPlantImage,
   updateMyPlant,
   getMyPlantLocations,
   DefaultPlantLocations,
@@ -28,7 +31,8 @@ it('Myplants is empty by default', () => {
 
 it('Can add to myplants', (done) => {
   // Add the plant
-  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', { sourceURL: 'testURL' })
+  const when = '2020-12-06T07:19:48.680Z';
+  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ sourceURL: 'testURL', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -40,7 +44,7 @@ it('Can add to myplants', (done) => {
           expect(myPlants[0].instanceID).toStrictEqual(instanceID);
           expect(myPlants[0].name).toStrictEqual('My Plant Name');
           expect(myPlants[0].location).toStrictEqual('Kitchen');
-          expect(myPlants[0].image).toStrictEqual({ sourceURL: 'testURL' });
+          expect(myPlants[0].images).toStrictEqual([{ sourceURL: 'testURL', date: when }]);
           done();
         });
     })
@@ -51,17 +55,18 @@ it('Can add to myplants', (done) => {
 
 it('Can own multiple plants', (done) => {
   // Add the first plant
-  addToMyPlants('MyPlantID1', 'My Plant Name 1', 'Kitchen', { sourceURL: 'testURL1' })
+  const when = '2020-12-06T07:19:48.680Z';
+  addToMyPlants('MyPlantID1', 'My Plant Name 1', 'Kitchen', [{ sourceURL: 'testURL1', date: when }])
     .then((instanceID1) => {
       expect(instanceID1).toBeTruthy();
 
       // Add the second plant
-      addToMyPlants('MyPlantID2', 'My Plant Name 2', 'Living room', { sourceURL: 'testURL2' })
+      addToMyPlants('MyPlantID2', 'My Plant Name 2', 'Living room', [{ sourceURL: 'testURL2', date: when }])
         .then((instanceID2) => {
           expect(instanceID2).toBeTruthy();
 
           // Add the third plant
-          addToMyPlants('MyPlantID3', 'My Plant Name 3', 'Porch', { sourceURL: 'testURL3' })
+          addToMyPlants('MyPlantID3', 'My Plant Name 3', 'Porch', [{ sourceURL: 'testURL3', date: when }])
             .then((instanceID3) => {
               expect(instanceID3).toBeTruthy();
 
@@ -74,17 +79,17 @@ it('Can own multiple plants', (done) => {
                   const plant1 = myPlants.find((cur) => cur.instanceID === instanceID1);
                   expect(plant1.name).toStrictEqual('My Plant Name 1');
                   expect(plant1.location).toStrictEqual('Kitchen');
-                  expect(plant1.image).toStrictEqual({ sourceURL: 'testURL1' });
+                  expect(plant1.images).toStrictEqual([{ sourceURL: 'testURL1', date: when }]);
 
                   const plant2 = myPlants.find((cur) => cur.instanceID === instanceID2);
                   expect(plant2.name).toStrictEqual('My Plant Name 2');
                   expect(plant2.location).toStrictEqual('Living room');
-                  expect(plant2.image).toStrictEqual({ sourceURL: 'testURL2' });
+                  expect(plant2.images).toStrictEqual([{ sourceURL: 'testURL2', date: when }]);
 
                   const plant3 = myPlants.find((cur) => cur.instanceID === instanceID3);
                   expect(plant3.name).toStrictEqual('My Plant Name 3');
                   expect(plant3.location).toStrictEqual('Porch');
-                  expect(plant3.image).toStrictEqual({ sourceURL: 'testURL3' });
+                  expect(plant3.images).toStrictEqual([{ sourceURL: 'testURL3', date: when }]);
                   done();
                 });
             })
@@ -103,17 +108,18 @@ it('Can own multiple plants', (done) => {
 
 it('Can remove from myplants', (done) => {
   // Add the first plant
-  addToMyPlants('MyPlantID1', 'My Plant Name 1', 'Kitchen', { sourceURL: 'testURL1' })
+  const when = '2020-12-06T07:19:48.680Z';
+  addToMyPlants('MyPlantID1', 'My Plant Name 1', 'Kitchen', [{ sourceURL: 'testURL1', date: when }])
     .then((instanceID1) => {
       expect(instanceID1).toBeTruthy();
 
       // Add the second plant
-      addToMyPlants('MyPlantID2', 'My Plant Name 2', 'Living room', { sourceURL: 'testURL2' })
+      addToMyPlants('MyPlantID2', 'My Plant Name 2', 'Living room', [{ sourceURL: 'testURL2', date: when }])
         .then((instanceID2) => {
           expect(instanceID2).toBeTruthy();
 
           // Add the third plant
-          addToMyPlants('MyPlantID3', 'My Plant Name 3', 'Porch', { sourceURL: 'testURL3' })
+          addToMyPlants('MyPlantID3', 'My Plant Name 3', 'Porch', [{ sourceURL: 'testURL3', date: when }])
             .then((instanceID3) => {
               expect(instanceID3).toBeTruthy();
 
@@ -129,7 +135,7 @@ it('Can remove from myplants', (done) => {
                       const plant1 = myPlants.find((cur) => cur.instanceID === instanceID1);
                       expect(plant1.name).toStrictEqual('My Plant Name 1');
                       expect(plant1.location).toStrictEqual('Kitchen');
-                      expect(plant1.image).toStrictEqual({ sourceURL: 'testURL1' });
+                      expect(plant1.images).toStrictEqual([{ sourceURL: 'testURL1', date: when }]);
 
                       const plant2 = myPlants.find((cur) => cur.instanceID === instanceID2);
                       expect(plant2).toBeUndefined();
@@ -137,7 +143,7 @@ it('Can remove from myplants', (done) => {
                       const plant3 = myPlants.find((cur) => cur.instanceID === instanceID3);
                       expect(plant3.name).toStrictEqual('My Plant Name 3');
                       expect(plant3.location).toStrictEqual('Porch');
-                      expect(plant3.image).toStrictEqual({ sourceURL: 'testURL3' });
+                      expect(plant3.images).toStrictEqual([{ sourceURL: 'testURL3', date: when }]);
                       done();
                     });
                 })
@@ -164,7 +170,8 @@ it('Cannot remove non-existing plant from myplants', () => {
 
 it('Can update plant name', (done) => {
   // Add the plant
-  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', { sourceURL: 'testURL' })
+  const when = '2020-12-06T07:19:48.680Z';
+  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ sourceURL: 'testURL', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -177,7 +184,7 @@ it('Can update plant name', (done) => {
             instanceID,
             name: 'My New Plant Name',
             location: 'Kitchen',
-            image: { sourceURL: 'testURL' },
+            images: [{ sourceURL: 'testURL', date: when }],
           });
 
           // Ensure that it is now updated in 'myplants'
@@ -200,7 +207,8 @@ it('Can update plant name', (done) => {
 
 it('Can update plant location', (done) => {
   // Add the plant
-  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', { sourceURL: 'testURL' })
+  const when = '2020-12-06T07:19:48.680Z';
+  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ sourceURL: 'testURL', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -213,43 +221,7 @@ it('Can update plant location', (done) => {
             instanceID,
             name: 'My Plant Name',
             location: 'New Location',
-            image: { sourceURL: 'testURL' },
-          });
-
-          // Ensure that it is now updated in 'myplants'
-          getMyPlants()
-            .then((myPlants) => {
-              expect(myPlants).toBeTruthy();
-              expect(myPlants).toHaveLength(1);
-              expect(myPlants[0]).toStrictEqual(newPlantState);
-              done();
-            });
-        })
-        .catch((error) => {
-          done(error);
-        });
-    })
-    .catch((error) => {
-      done(error);
-    });
-});
-
-it('Can update plant image by URL', (done) => {
-  // Add the plant
-  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', { sourceURL: 'testURL' })
-    .then((instanceID) => {
-      expect(instanceID).toBeTruthy();
-
-      // Update the plant's image URL
-      updateMyPlant(instanceID, { image: { sourceURL: 'newURL' } })
-        .then((newPlantState) => {
-          // Ensure that the resolved plant matches what's expected
-          expect(newPlantState).toStrictEqual({
-            plantID: 'MyPlantID',
-            instanceID,
-            name: 'My Plant Name',
-            location: 'Kitchen',
-            image: { sourceURL: 'newURL' },
+            images: [{ sourceURL: 'testURL', date: when }],
           });
 
           // Ensure that it is now updated in 'myplants'
@@ -272,7 +244,8 @@ it('Can update plant image by URL', (done) => {
 
 it('Can update multiple plant properties simultaneously', (done) => {
   // Add the plant
-  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', { sourceURL: 'testURL' })
+  const when = '2020-12-06T07:19:48.680Z';
+  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ sourceURL: 'testURL', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -280,7 +253,6 @@ it('Can update multiple plant properties simultaneously', (done) => {
       updateMyPlant(instanceID, {
         name: 'My New Plant Name',
         location: 'Porch',
-        image: { sourceURL: 'newURL' },
       })
         .then((newPlantState) => {
           // Ensure that the resolved plant matches what's expected
@@ -289,7 +261,7 @@ it('Can update multiple plant properties simultaneously', (done) => {
             instanceID,
             name: 'My New Plant Name',
             location: 'Porch',
-            image: { sourceURL: 'newURL' },
+            images: [{ sourceURL: 'testURL', date: when }],
           });
 
           // Ensure that it is now updated in 'myplants'
@@ -310,32 +282,28 @@ it('Can update multiple plant properties simultaneously', (done) => {
     });
 });
 
+//TODO: Test multiple plant images and removing plant images
+
 it('Can update plant image by base64', (done) => {
   // Add the plant
-  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', { sourceURL: 'testURL' })
+  const when = '2020-12-06T07:19:48.680Z';
+  const newWhen = '2020-12-07T07:19:48.680Z';
+  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ sourceURL: 'testURL', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
       // Update the plant's image by base64
-      updateMyPlant(instanceID, { image: { base64: 'SGVsbG8=' } })
-        .then((newPlantState) => {
-          // Ensure that the resolved plant matches what's expected
-          expect(newPlantState.plantID).toStrictEqual('MyPlantID');
-          expect(newPlantState.instanceID).toStrictEqual(instanceID);
-          expect(newPlantState.name).toStrictEqual('My Plant Name');
-          expect(newPlantState.location).toStrictEqual('Kitchen');
-          expect(newPlantState.image.authenticationRequired).toBe(true);
-          expect(newPlantState.image.sourceURL).toBeTruthy();
-
+      updateMyPlantImage(instanceID, 0, 'SGVsbG8=', newWhen)
+        .then(() => {
           // Ensure that it is now updated in 'myplants'
           getMyPlants()
             .then((myPlants) => {
               expect(myPlants).toBeTruthy();
               expect(myPlants).toHaveLength(1);
-              expect(myPlants[0]).toStrictEqual(newPlantState);
 
+              const newPlantState = myPlants.find((cur) => cur.instanceID === instanceID);
               // And ensure that we can load the image via an authFetch
-              authFetch(newPlantState.image.sourceURL)
+              authFetch(newPlantState.images[0].sourceURL)
                 .then((imageResponse) => {
                   expect(imageResponse).toStrictEqual('SGVsbG8=');
                   done();
@@ -365,7 +333,8 @@ it('Plant locations optionally include defaults when empty', () => {
 it('Single default plant location works', (done) => {
   // Add the plant
   const location = DefaultPlantLocations[1];
-  addToMyPlants('MyPlantID', 'My Plant Name', location, { sourceURL: 'testURL' })
+  const when = '2020-12-06T07:19:48.680Z';
+  addToMyPlants('MyPlantID', 'My Plant Name', location, [{ sourceURL: 'testURL', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -388,7 +357,8 @@ it('Single default plant location works', (done) => {
 it('Single custom plant location works', (done) => {
   // Add the plant
   const location = 'My custom location';
-  addToMyPlants('MyPlantID', 'My Plant Name', location, { sourceURL: 'testURL' })
+  const when = '2020-12-06T07:19:48.680Z';
+  addToMyPlants('MyPlantID', 'My Plant Name', location, [{ sourceURL: 'testURL', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -411,7 +381,8 @@ it('Single custom plant location works', (done) => {
 it('Mix custom and default plant locations works', (done) => {
   // Add the plant
   const location = 'My custom location';
-  addToMyPlants('MyPlantID', 'My Plant Name', location, { sourceURL: 'testURL' })
+  const when = '2020-12-06T07:19:48.680Z';
+  addToMyPlants('MyPlantID', 'My Plant Name', location, [{ sourceURL: 'testURL', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -434,7 +405,8 @@ it('Mix custom and default plant locations works', (done) => {
 it('Owning plants in default locations will not cause duplicate rooms', (done) => {
   // Add the plant
   const location = DefaultPlantLocations[2];
-  addToMyPlants('MyPlantID', 'My Plant Name', location, { sourceURL: 'testURL' })
+  const when = '2020-12-06T07:19:48.680Z';
+  addToMyPlants('MyPlantID', 'My Plant Name', location, [{ sourceURL: 'testURL', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -455,48 +427,49 @@ it('Owning plants in default locations will not cause duplicate rooms', (done) =
 });
 
 it('Group plants by location works', () => {
+  const when = '2020-12-06T07:19:48.680Z';
   const plants = [
     {
       instanceID: 'Instance1',
       plantID: 'MyID1',
       name: 'My First Plant',
       location: 'Location A',
-      image: { sourceURL: 'testURL' },
+      images: [{ sourceURL: 'testURL', date: when }],
     },
     {
       instanceID: 'Instance2',
       plantID: 'MyID2',
       name: 'My Second Plant',
       location: 'Location B',
-      image: { sourceURL: 'testURL' },
+      images: [{ sourceURL: 'testURL', date: when }],
     },
     {
       instanceID: 'Instance3',
       plantID: 'MyID3',
       name: 'My Third Plant',
       location: 'Location C',
-      image: { sourceURL: 'testURL' },
+      images: [{ sourceURL: 'testURL', date: when }],
     },
     {
       instanceID: 'Instance4',
       plantID: 'MyID4',
       name: 'My Fourth Plant',
       location: 'Location C',
-      image: { sourceURL: 'testURL' },
+      images: [{ sourceURL: 'testURL', date: when }],
     },
     {
       instanceID: 'Instance5',
       plantID: 'MyID5',
       name: 'My Fifth Plant',
       location: 'Location A',
-      image: { sourceURL: 'testURL' },
+      images: [{ sourceURL: 'testURL', date: when }],
     },
     {
       instanceID: 'Instance6',
       plantID: 'MyID6',
       name: 'My Sixth Plant',
       location: 'Location B',
-      image: { sourceURL: 'testURL' },
+      images: [{ sourceURL: 'testURL', date: when }],
     },
   ];
 

--- a/frontend/api/tests/myplants.test.js
+++ b/frontend/api/tests/myplants.test.js
@@ -32,7 +32,7 @@ it('Myplants is empty by default', () => {
 it('Can add to myplants', (done) => {
   // Add the plant
   const when = '2020-12-06T07:19:48.680Z';
-  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ sourceURL: 'testURL', date: when }])
+  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ base64: 'SGVsbG8', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -44,7 +44,30 @@ it('Can add to myplants', (done) => {
           expect(myPlants[0].instanceID).toStrictEqual(instanceID);
           expect(myPlants[0].name).toStrictEqual('My Plant Name');
           expect(myPlants[0].location).toStrictEqual('Kitchen');
-          expect(myPlants[0].images).toStrictEqual([{ sourceURL: 'testURL', date: when }]);
+          expect(myPlants[0].images[0].sourceURL).toMatch('http');
+          done();
+        });
+    })
+    .catch((error) => {
+      done(error);
+    });
+});
+
+it('Can add plant with no image', (done) => {
+  // Add the plant
+  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [])
+    .then((instanceID) => {
+      expect(instanceID).toBeTruthy();
+
+      // Ensure that it is now stored in 'myplants'
+      getMyPlants()
+        .then((myPlants) => {
+          expect(myPlants).toBeTruthy();
+          expect(myPlants).toHaveLength(1);
+          expect(myPlants[0].instanceID).toStrictEqual(instanceID);
+          expect(myPlants[0].name).toStrictEqual('My Plant Name');
+          expect(myPlants[0].location).toStrictEqual('Kitchen');
+          expect(myPlants[0].images).toHaveLength(0);
           done();
         });
     })
@@ -56,17 +79,17 @@ it('Can add to myplants', (done) => {
 it('Can own multiple plants', (done) => {
   // Add the first plant
   const when = '2020-12-06T07:19:48.680Z';
-  addToMyPlants('MyPlantID1', 'My Plant Name 1', 'Kitchen', [{ sourceURL: 'testURL1', date: when }])
+  addToMyPlants('MyPlantID1', 'My Plant Name 1', 'Kitchen', [{ base64: 'SGVsbG7', date: when }])
     .then((instanceID1) => {
       expect(instanceID1).toBeTruthy();
 
       // Add the second plant
-      addToMyPlants('MyPlantID2', 'My Plant Name 2', 'Living room', [{ sourceURL: 'testURL2', date: when }])
+      addToMyPlants('MyPlantID2', 'My Plant Name 2', 'Living room', [{ base64: 'SGVsbG8', date: when }])
         .then((instanceID2) => {
           expect(instanceID2).toBeTruthy();
 
           // Add the third plant
-          addToMyPlants('MyPlantID3', 'My Plant Name 3', 'Porch', [{ sourceURL: 'testURL3', date: when }])
+          addToMyPlants('MyPlantID3', 'My Plant Name 3', 'Porch', [{ base64: 'SGVsbG9', date: when }])
             .then((instanceID3) => {
               expect(instanceID3).toBeTruthy();
 
@@ -79,17 +102,20 @@ it('Can own multiple plants', (done) => {
                   const plant1 = myPlants.find((cur) => cur.instanceID === instanceID1);
                   expect(plant1.name).toStrictEqual('My Plant Name 1');
                   expect(plant1.location).toStrictEqual('Kitchen');
-                  expect(plant1.images).toStrictEqual([{ sourceURL: 'testURL1', date: when }]);
+                  expect(plant1.images).toHaveLength(1);
+                  expect(plant1.images[0].sourceURL).toMatch('http');
 
                   const plant2 = myPlants.find((cur) => cur.instanceID === instanceID2);
                   expect(plant2.name).toStrictEqual('My Plant Name 2');
                   expect(plant2.location).toStrictEqual('Living room');
-                  expect(plant2.images).toStrictEqual([{ sourceURL: 'testURL2', date: when }]);
+                  expect(plant2.images).toHaveLength(1);
+                  expect(plant2.images[0].sourceURL).toMatch('http');
 
                   const plant3 = myPlants.find((cur) => cur.instanceID === instanceID3);
                   expect(plant3.name).toStrictEqual('My Plant Name 3');
                   expect(plant3.location).toStrictEqual('Porch');
-                  expect(plant3.images).toStrictEqual([{ sourceURL: 'testURL3', date: when }]);
+                  expect(plant3.images).toHaveLength(1);
+                  expect(plant3.images[0].sourceURL).toMatch('http');
                   done();
                 });
             })
@@ -109,17 +135,17 @@ it('Can own multiple plants', (done) => {
 it('Can remove from myplants', (done) => {
   // Add the first plant
   const when = '2020-12-06T07:19:48.680Z';
-  addToMyPlants('MyPlantID1', 'My Plant Name 1', 'Kitchen', [{ sourceURL: 'testURL1', date: when }])
+  addToMyPlants('MyPlantID1', 'My Plant Name 1', 'Kitchen', [{ base64: 'SGVsbG7', date: when }])
     .then((instanceID1) => {
       expect(instanceID1).toBeTruthy();
 
       // Add the second plant
-      addToMyPlants('MyPlantID2', 'My Plant Name 2', 'Living room', [{ sourceURL: 'testURL2', date: when }])
+      addToMyPlants('MyPlantID2', 'My Plant Name 2', 'Living room', [{ base64: 'SGVsbG8', date: when }])
         .then((instanceID2) => {
           expect(instanceID2).toBeTruthy();
 
           // Add the third plant
-          addToMyPlants('MyPlantID3', 'My Plant Name 3', 'Porch', [{ sourceURL: 'testURL3', date: when }])
+          addToMyPlants('MyPlantID3', 'My Plant Name 3', 'Porch', [{ base64: 'SGVsbG9', date: when }])
             .then((instanceID3) => {
               expect(instanceID3).toBeTruthy();
 
@@ -135,7 +161,8 @@ it('Can remove from myplants', (done) => {
                       const plant1 = myPlants.find((cur) => cur.instanceID === instanceID1);
                       expect(plant1.name).toStrictEqual('My Plant Name 1');
                       expect(plant1.location).toStrictEqual('Kitchen');
-                      expect(plant1.images).toStrictEqual([{ sourceURL: 'testURL1', date: when }]);
+                      expect(plant1.images).toHaveLength(1);
+                      expect(plant1.images[0].sourceURL).toMatch('http');
 
                       const plant2 = myPlants.find((cur) => cur.instanceID === instanceID2);
                       expect(plant2).toBeUndefined();
@@ -143,7 +170,8 @@ it('Can remove from myplants', (done) => {
                       const plant3 = myPlants.find((cur) => cur.instanceID === instanceID3);
                       expect(plant3.name).toStrictEqual('My Plant Name 3');
                       expect(plant3.location).toStrictEqual('Porch');
-                      expect(plant3.images).toStrictEqual([{ sourceURL: 'testURL3', date: when }]);
+                      expect(plant3.images).toHaveLength(1);
+                      expect(plant3.images[0].sourceURL).toMatch('http');
                       done();
                     });
                 })
@@ -171,7 +199,7 @@ it('Cannot remove non-existing plant from myplants', () => {
 it('Can update plant name', (done) => {
   // Add the plant
   const when = '2020-12-06T07:19:48.680Z';
-  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ sourceURL: 'testURL', date: when }])
+  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ base64: 'SGVsbG8', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -179,13 +207,12 @@ it('Can update plant name', (done) => {
       updateMyPlant(instanceID, { name: 'My New Plant Name' })
         .then((newPlantState) => {
           // Ensure that the resolved plant matches what's expected
-          expect(newPlantState).toStrictEqual({
-            plantID: 'MyPlantID',
-            instanceID,
-            name: 'My New Plant Name',
-            location: 'Kitchen',
-            images: [{ sourceURL: 'testURL', date: when }],
-          });
+          expect(newPlantState.plantID).toStrictEqual('MyPlantID');
+          expect(newPlantState.instanceID).toStrictEqual(instanceID);
+          expect(newPlantState.name).toStrictEqual('My New Plant Name');
+          expect(newPlantState.location).toStrictEqual('Kitchen');
+          expect(newPlantState.images).toHaveLength(1);
+          expect(newPlantState.images[0].sourceURL).toMatch('http');
 
           // Ensure that it is now updated in 'myplants'
           getMyPlants()
@@ -208,7 +235,7 @@ it('Can update plant name', (done) => {
 it('Can update plant location', (done) => {
   // Add the plant
   const when = '2020-12-06T07:19:48.680Z';
-  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ sourceURL: 'testURL', date: when }])
+  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ base64: 'SGVsbG8', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -216,13 +243,12 @@ it('Can update plant location', (done) => {
       updateMyPlant(instanceID, { location: 'New Location' })
         .then((newPlantState) => {
           // Ensure that the resolved plant matches what's expected
-          expect(newPlantState).toStrictEqual({
-            plantID: 'MyPlantID',
-            instanceID,
-            name: 'My Plant Name',
-            location: 'New Location',
-            images: [{ sourceURL: 'testURL', date: when }],
-          });
+          expect(newPlantState.plantID).toStrictEqual('MyPlantID');
+          expect(newPlantState.instanceID).toStrictEqual(instanceID);
+          expect(newPlantState.name).toStrictEqual('My Plant Name');
+          expect(newPlantState.location).toStrictEqual('New Location');
+          expect(newPlantState.images).toHaveLength(1);
+          expect(newPlantState.images[0].sourceURL).toMatch('http');
 
           // Ensure that it is now updated in 'myplants'
           getMyPlants()
@@ -245,7 +271,7 @@ it('Can update plant location', (done) => {
 it('Can update multiple plant properties simultaneously', (done) => {
   // Add the plant
   const when = '2020-12-06T07:19:48.680Z';
-  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ sourceURL: 'testURL', date: when }])
+  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ base64: 'SGVsbG8', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -255,14 +281,12 @@ it('Can update multiple plant properties simultaneously', (done) => {
         location: 'Porch',
       })
         .then((newPlantState) => {
-          // Ensure that the resolved plant matches what's expected
-          expect(newPlantState).toStrictEqual({
-            plantID: 'MyPlantID',
-            instanceID,
-            name: 'My New Plant Name',
-            location: 'Porch',
-            images: [{ sourceURL: 'testURL', date: when }],
-          });
+          expect(newPlantState.plantID).toStrictEqual('MyPlantID');
+          expect(newPlantState.instanceID).toStrictEqual(instanceID);
+          expect(newPlantState.name).toStrictEqual('My New Plant Name');
+          expect(newPlantState.location).toStrictEqual('Porch');
+          expect(newPlantState.images).toHaveLength(1);
+          expect(newPlantState.images[0].sourceURL).toMatch('http');
 
           // Ensure that it is now updated in 'myplants'
           getMyPlants()
@@ -384,7 +408,7 @@ it('Can update plant image by base64', (done) => {
   // Add the plant
   const when = '2020-12-06T07:19:48.680Z';
   const newWhen = '2020-12-07T07:19:48.680Z';
-  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ sourceURL: 'testURL', date: when }])
+  addToMyPlants('MyPlantID', 'My Plant Name', 'Kitchen', [{ base64: 'd29ybGQ=', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -430,7 +454,7 @@ it('Single default plant location works', (done) => {
   // Add the plant
   const location = DefaultPlantLocations[1];
   const when = '2020-12-06T07:19:48.680Z';
-  addToMyPlants('MyPlantID', 'My Plant Name', location, [{ sourceURL: 'testURL', date: when }])
+  addToMyPlants('MyPlantID', 'My Plant Name', location, [{ base64: 'SGVsbG8', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -454,7 +478,7 @@ it('Single custom plant location works', (done) => {
   // Add the plant
   const location = 'My custom location';
   const when = '2020-12-06T07:19:48.680Z';
-  addToMyPlants('MyPlantID', 'My Plant Name', location, [{ sourceURL: 'testURL', date: when }])
+  addToMyPlants('MyPlantID', 'My Plant Name', location, [{ base64: 'SGVsbG8', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -478,7 +502,7 @@ it('Mix custom and default plant locations works', (done) => {
   // Add the plant
   const location = 'My custom location';
   const when = '2020-12-06T07:19:48.680Z';
-  addToMyPlants('MyPlantID', 'My Plant Name', location, [{ sourceURL: 'testURL', date: when }])
+  addToMyPlants('MyPlantID', 'My Plant Name', location, [{ base64: 'SGVsbG8', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -502,7 +526,7 @@ it('Owning plants in default locations will not cause duplicate rooms', (done) =
   // Add the plant
   const location = DefaultPlantLocations[2];
   const when = '2020-12-06T07:19:48.680Z';
-  addToMyPlants('MyPlantID', 'My Plant Name', location, [{ sourceURL: 'testURL', date: when }])
+  addToMyPlants('MyPlantID', 'My Plant Name', location, [{ base64: 'SGVsbG8', date: when }])
     .then((instanceID) => {
       expect(instanceID).toBeTruthy();
 
@@ -530,42 +554,42 @@ it('Group plants by location works', () => {
       plantID: 'MyID1',
       name: 'My First Plant',
       location: 'Location A',
-      images: [{ sourceURL: 'testURL', date: when }],
+      images: [{ base64: 'SGVsbG8', date: when }],
     },
     {
       instanceID: 'Instance2',
       plantID: 'MyID2',
       name: 'My Second Plant',
       location: 'Location B',
-      images: [{ sourceURL: 'testURL', date: when }],
+      images: [{ base64: 'SGVsbG8', date: when }],
     },
     {
       instanceID: 'Instance3',
       plantID: 'MyID3',
       name: 'My Third Plant',
       location: 'Location C',
-      images: [{ sourceURL: 'testURL', date: when }],
+      images: [{ base64: 'SGVsbG8', date: when }],
     },
     {
       instanceID: 'Instance4',
       plantID: 'MyID4',
       name: 'My Fourth Plant',
       location: 'Location C',
-      images: [{ sourceURL: 'testURL', date: when }],
+      images: [{ base64: 'SGVsbG8', date: when }],
     },
     {
       instanceID: 'Instance5',
       plantID: 'MyID5',
       name: 'My Fifth Plant',
       location: 'Location A',
-      images: [{ sourceURL: 'testURL', date: when }],
+      images: [{ base64: 'SGVsbG8', date: when }],
     },
     {
       instanceID: 'Instance6',
       plantID: 'MyID6',
       name: 'My Sixth Plant',
       location: 'Location B',
-      images: [{ sourceURL: 'testURL', date: when }],
+      images: [{ base64: 'SGVsbG8', date: when }],
     },
   ];
 

--- a/frontend/components/Plants/AddMyPlantDialog.jsx
+++ b/frontend/components/Plants/AddMyPlantDialog.jsx
@@ -84,10 +84,12 @@ class AddMyPlantDialog extends React.Component {
       image = {
         base64: customImage,
       };
-    } else {
+    } else if (plant.image) {
       image = {
         sourceURL: plant.image.sourceURL,
       };
+    } else {
+      image = { sourceURL: '' };// TODO: I don't like this
     }
 
     this.setState({ uploading: true });
@@ -225,6 +227,8 @@ class AddMyPlantDialog extends React.Component {
     const galleryIcon = (info) => (<Icon {...info} name={customImageMode === 'gallery' ? 'image-outline' : 'image'} />);
     const pictureButtonStyle = { width: 25, height: 25, marginRight: '5%' };
 
+    const defaultImageURL = plant.image ? plant.image.sourceURL : '';// TODO: Use proper default?
+
     return (
       <View>
         <Portal>
@@ -258,7 +262,7 @@ class AddMyPlantDialog extends React.Component {
               </Layout>
               <View style={{ maxWidth: '100%', height: 220, flex: 0 }}>
                 <Image
-                  source={{ uri: customImage ? `data:image/jpeg;base64,${customImage}` : plant.image.sourceURL }}
+                  source={{ uri: customImage ? `data:image/jpeg;base64,${customImage}` : defaultImageURL }}
                   style={{ maxWidth: '100%', flex: 1 }}
                   resizeMode="cover"
                 />

--- a/frontend/components/Plants/AddMyPlantDialog.jsx
+++ b/frontend/components/Plants/AddMyPlantDialog.jsx
@@ -79,21 +79,15 @@ class AddMyPlantDialog extends React.Component {
     const { plant, onSubmit, onCancel } = this.props;
     const { locations, locationIndex, customImage } = this.state;
 
-    let image;
+    const images = [];
     if (customImage) {
-      image = {
+      images.push({
         base64: customImage,
-      };
-    } else if (plant.image) {
-      image = {
-        sourceURL: plant.image.sourceURL,
-      };
-    } else {
-      image = { sourceURL: '' };// TODO: I don't like this
+      });
     }
 
     this.setState({ uploading: true });
-    addToMyPlants(plant.plantID, plant.name, locations[locationIndex - 1], image)
+    addToMyPlants(plant.plantID, plant.name, locations[locationIndex - 1], images)
       .then(() => {
         // Reset state for future use
         this.setState({ locationIndex: 0, uploading: false });
@@ -227,8 +221,6 @@ class AddMyPlantDialog extends React.Component {
     const galleryIcon = (info) => (<Icon {...info} name={customImageMode === 'gallery' ? 'image-outline' : 'image'} />);
     const pictureButtonStyle = { width: 25, height: 25, marginRight: '5%' };
 
-    const defaultImageURL = plant.image ? plant.image.sourceURL : '';// TODO: Use proper default?
-
     return (
       <View>
         <Portal>
@@ -262,7 +254,7 @@ class AddMyPlantDialog extends React.Component {
               </Layout>
               <View style={{ maxWidth: '100%', height: 220, flex: 0 }}>
                 <Image
-                  source={{ uri: customImage ? `data:image/jpeg;base64,${customImage}` : defaultImageURL }}
+                  source={{ uri: customImage ? `data:image/jpeg;base64,${customImage}` : plant.image.sourceURL }}
                   style={{ maxWidth: '100%', flex: 1 }}
                   resizeMode="cover"
                 />

--- a/frontend/components/Plants/CardItem.jsx
+++ b/frontend/components/Plants/CardItem.jsx
@@ -284,8 +284,14 @@ class CardItem extends React.Component {
       image = (
         <SliderBox
           images={plant.images}
-          sliderBoxHeight={200}
           ImageComponent={PlantImage}
+          ImageComponentStyle={styles.image}
+          imageLoadingColor="#00000000"
+          style={{
+            height: 320,
+            marginRight: 85,
+            alignItems: 'center',
+          }}
         />
       );
     } else if (fallbackImage) {

--- a/frontend/components/Plants/CardItem.jsx
+++ b/frontend/components/Plants/CardItem.jsx
@@ -10,11 +10,12 @@ import { PropTypes } from 'prop-types';
 import {
   Button, Card, Icon, Layout, Spinner, Text,
 } from '@ui-kitten/components';
+import { SliderBox } from 'react-native-image-slider-box';
 import * as ImagePicker from 'expo-image-picker';
 import AddMyPlantDialog from './AddMyPlantDialog';
 import PlantImage from './PlantImage';
 
-const { getMyPlants, updateMyPlant, removeFromMyPlants } = require('../../api/myplants');
+const { getMyPlants, updateMyPlant, removeFromMyPlants, addMyPlantImage } = require('../../api/myplants');
 const { isFavorite, addToFavorites, removeFromFavorites } = require('../../api/favoritePlants');
 
 class CardItem extends React.Component {
@@ -83,7 +84,7 @@ class CardItem extends React.Component {
         }).then((imageResult) => {
           if (!imageResult.cancelled) {
             this.setState({ imageUploading: true });
-            updateMyPlant(plant.instanceID, { image: { base64: imageResult.base64 } })
+            addMyPlantImage(plant.instanceID, imageResult.base64, new Date())
               .then(() => {
                 this.setState({
                   imageUploading: false,
@@ -247,6 +248,30 @@ class CardItem extends React.Component {
       </Layout>
     );
 
+    console.log(`Plant=${JSON.stringify(plant)}`);
+
+    let image = plant.image
+      ? (
+        <PlantImage
+          source={{
+            sourceURL: plant.image.sourceURL,
+            authenticationRequired: plant.image.authenticationRequired === true,
+          }}
+          style={styles.image}
+          imageRefreshCounter={imageRefreshCounter}
+        />
+      ) : (
+        <SliderBox
+          images={plant.images}
+          sliderBoxHeight={200}
+          ImageComponent={PlantImage}
+        />
+      );
+
+    if (imageUploading) {
+      image = undefined;
+    }
+
     return (
       <View>
         <AddMyPlantDialog
@@ -265,16 +290,7 @@ class CardItem extends React.Component {
           footer={renderItemFooter}
           onPress={() => { onPressItem(plant); }}
         >
-          {imageUploading
-            ? (<Spinner />)
-            : (
-              <PlantImage
-                sourceURL={plant.image.sourceURL}
-                authenticationRequired={plant.image.authenticationRequired}
-                style={styles.image}
-                imageRefreshCounter={imageRefreshCounter}
-              />
-            )}
+          {image}
         </Card>
       </View>
     );

--- a/frontend/components/Plants/Collection/MyPlantsList.jsx
+++ b/frontend/components/Plants/Collection/MyPlantsList.jsx
@@ -75,7 +75,7 @@ class MyPlantsList extends Component {
           styles={styles}
           onPressItem={onPressItem}
           onRemoveFromOwned={this.removePlant}
-          allowChangePicture
+          isCustomized
         />
       ));
       cardsAndHeaders.push((

--- a/frontend/components/Plants/PlantImage.jsx
+++ b/frontend/components/Plants/PlantImage.jsx
@@ -16,7 +16,8 @@ class PlantImage extends React.Component {
   }
 
   componentDidMount() {
-    const { sourceURL, authenticationRequired } = this.props;
+    const { source } = this.props;
+    const { sourceURL, authenticationRequired } = source;
     if (authenticationRequired) {
       authFetch(sourceURL).then((res) => {
         this.setState({ base64: res });
@@ -29,8 +30,10 @@ class PlantImage extends React.Component {
 
   render() {
     const { base64, error } = this.state;
-    const { sourceURL, authenticationRequired } = this.props;
+    const { source } = this.props;
+    const { sourceURL, authenticationRequired } = source;
 
+    console.log(`Props are: ${JSON.stringify(this.props)}`);
     if (error) {
       return (<Icon name="alert-triangle-outline" fill="red" />);
     }
@@ -38,7 +41,7 @@ class PlantImage extends React.Component {
       return (<Image {...this.props} source={{ uri: `data:image/jpeg;base64,${base64}` }} />);
     }
     if (!authenticationRequired) {
-      return (<Image source={{ uri: sourceURL }} {...this.props} />);
+      return (<Image {...this.props} source={{ uri: sourceURL }} />);
     }
 
     return (<Spinner />);
@@ -46,12 +49,10 @@ class PlantImage extends React.Component {
 }
 
 PlantImage.propTypes = {
-  sourceURL: PropTypes.string.isRequired,
-  authenticationRequired: PropTypes.bool,
-};
-
-PlantImage.defaultProps = {
-  authenticationRequired: false,
+  source: PropTypes.shape({
+    sourceURL: PropTypes.string.isRequired,
+    authenticationRequired: PropTypes.bool,
+  }).isRequired,
 };
 
 export default PlantImage;

--- a/frontend/components/Plants/PlantImage.jsx
+++ b/frontend/components/Plants/PlantImage.jsx
@@ -33,7 +33,6 @@ class PlantImage extends React.Component {
     const { source } = this.props;
     const { sourceURL, authenticationRequired } = source;
 
-    console.log(`Props are: ${JSON.stringify(this.props)}`);
     if (error) {
       return (<Icon name="alert-triangle-outline" fill="red" />);
     }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -12732,6 +12732,36 @@
         "prop-types": "^15.6.2"
       }
     },
+    "react-addons-shallow-compare": {
+      "version": "15.6.2",
+      "resolved": "https://registry.npmjs.org/react-addons-shallow-compare/-/react-addons-shallow-compare-15.6.2.tgz",
+      "integrity": "sha1-GYoAuR/DdiPbZKKP0XtZa6NicC8=",
+      "requires": {
+        "fbjs": "^0.8.4",
+        "object-assign": "^4.1.0"
+      },
+      "dependencies": {
+        "core-js": {
+          "version": "1.2.7",
+          "resolved": "https://registry.npmjs.org/core-js/-/core-js-1.2.7.tgz",
+          "integrity": "sha1-ZSKUwUZR2yj6k70tX/KYOk8IxjY="
+        },
+        "fbjs": {
+          "version": "0.8.17",
+          "resolved": "https://registry.npmjs.org/fbjs/-/fbjs-0.8.17.tgz",
+          "integrity": "sha1-xNWY6taUkRJlPWWIsBpc3Nn5D90=",
+          "requires": {
+            "core-js": "^1.0.0",
+            "isomorphic-fetch": "^2.1.1",
+            "loose-envify": "^1.0.0",
+            "object-assign": "^4.1.0",
+            "promise": "^7.1.1",
+            "setimmediate": "^1.0.5",
+            "ua-parser-js": "^0.7.18"
+          }
+        }
+      }
+    },
     "react-devtools-core": {
       "version": "4.8.2",
       "resolved": "https://registry.npmjs.org/react-devtools-core/-/react-devtools-core-4.8.2.tgz",
@@ -13287,6 +13317,14 @@
         "prop-types": "^15.7.2"
       }
     },
+    "react-native-image-slider-box": {
+      "version": "1.0.12",
+      "resolved": "https://registry.npmjs.org/react-native-image-slider-box/-/react-native-image-slider-box-1.0.12.tgz",
+      "integrity": "sha512-Yq7xLmrAxNWjSAZJ78ZQkg13/30UJc17yvBwRFAidGrMaVo2Go9glRdRJ2U212APsQVHskAhSgW6YHinuTLoIA==",
+      "requires": {
+        "react-native-snap-carousel": "*"
+      }
+    },
     "react-native-input-prompt": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/react-native-input-prompt/-/react-native-input-prompt-1.0.0.tgz",
@@ -13362,6 +13400,15 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/react-native-size-matters/-/react-native-size-matters-0.3.1.tgz",
       "integrity": "sha512-mKOfBLIBFBcs9br1rlZDvxD5+mAl8Gfr5CounwJtxI6Z82rGrMO+Kgl9EIg3RMVf3G855a85YVqHJL2f5EDRlw=="
+    },
+    "react-native-snap-carousel": {
+      "version": "3.9.1",
+      "resolved": "https://registry.npmjs.org/react-native-snap-carousel/-/react-native-snap-carousel-3.9.1.tgz",
+      "integrity": "sha512-xWEGusacIgK1YaDXLi7Gao2+ISLoGPVEBR8fcMf4tOOJQufutlNwkoLu0l6B8Qgsrre0nTxoVZikRgGRDWlLaQ==",
+      "requires": {
+        "prop-types": "^15.6.1",
+        "react-addons-shallow-compare": "15.6.2"
+      }
     },
     "react-native-status-bar-height": {
       "version": "2.6.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -19,9 +19,12 @@
     "dotenv": "^8.2.0",
     "expo": "~39.0.2",
     "expo-camera": "~9.0.0",
+    "expo-image-picker": "~9.1.0",
+    "expo-permissions": "~9.3.0",
     "expo-splash-screen": "~0.6.0",
     "expo-status-bar": "~1.0.2",
     "expo-updates": "~0.3.2",
+    "node-fetch": "^2.6.1",
     "prop-types": "^15.7.2",
     "react": "16.13.1",
     "react-dom": "16.13.1",
@@ -31,6 +34,7 @@
     "react-native-collapsible": "^1.5.3",
     "react-native-elements": "^3.0.0-alpha.1",
     "react-native-gesture-handler": "~1.7.0",
+    "react-native-image-slider-box": "^1.0.12",
     "react-native-input-prompt": "^1.0.0",
     "react-native-paper": "^4.4.0",
     "react-native-picker-select": "^8.0.2",
@@ -39,10 +43,7 @@
     "react-native-screens": "~2.10.1",
     "react-native-svg": "12.1.0",
     "react-native-unimodules": "~0.11.0",
-    "react-native-web": "~0.13.12",
-    "expo-image-picker": "~9.1.0",
-    "expo-permissions": "~9.3.0",
-    "node-fetch": "^2.6.1"
+    "react-native-web": "~0.13.12"
   },
   "devDependencies": {
     "@babel/core": "~7.9.0",


### PR DESCRIPTION
- Changed backend to support multiple images per plant, as well as 'none' (in which case frontend uses a default).
- Changed `CardItem` to show multiple images per owned plant.
- Updated `AddMyPlantDialog` to support the API changes.