### PR TITLE
Change profile page to show ownership info

### DIFF
--- a/frontend/components/Navigation/Navigation.jsx
+++ b/frontend/components/Navigation/Navigation.jsx
@@ -61,13 +61,8 @@ function Navigation() {
     {
       name: 'PlantProfile',
       component: PlantProfileScreen,
-      options: (navContext) => {
-        if (navContext.route.params) {
-          return ({
-            title: navContext.route.params.plantName ?? 'Plant Profile',
-          });
-        }
-        return { title: 'Plant Profile' };
+      options: {
+        headerShown: false,
       },
     },
     {

--- a/frontend/components/Plants/AddMyPlantDialog.jsx
+++ b/frontend/components/Plants/AddMyPlantDialog.jsx
@@ -87,7 +87,7 @@ class AddMyPlantDialog extends React.Component {
       customImage,
     } = this.state;
 
-    const plantName = nickname ?? plant.plantName;
+    const plantName = nickname ?? plant.name;
 
     const images = [];
     if (customImage) {

--- a/frontend/components/Plants/PlantProfile.jsx
+++ b/frontend/components/Plants/PlantProfile.jsx
@@ -4,10 +4,14 @@ import {
 import React, { Component } from 'react';
 import PropTypes from 'prop-types';
 import {
-  View, Image,
+  View,
 } from 'react-native';
 import { ScrollView } from 'react-native-gesture-handler';
-import { SERVER_ADDR } from '../../server';
+import CardItem from './CardItem';
+
+const {
+  getPlantInfo,
+} = require('../../api/plants');
 
 class PlantProfile extends Component {
   constructor() {
@@ -23,15 +27,14 @@ class PlantProfile extends Component {
     const profileThis = this;
     const { plantID } = this.props;
 
-    fetch(`${SERVER_ADDR}/plants/${plantID}`)
-      .then((response) => response.json())
+    getPlantInfo(plantID)
       .then((data) => {
         profileThis.setState({
           loaded: true,
           plantData: data,
         });
       }, (error) => {
-        console.log(`Failed to load a tip. Reason: ${error}`);
+        console.log(`Failed to load plant data. Reason: ${error}`);
         profileThis.setState({ error });
       });
   }
@@ -169,7 +172,6 @@ class PlantProfile extends Component {
   }
 
   render() {
-    const { hideTitle } = this.props;
     const { loaded, error, plantData } = this.state;
     if (error) {
       const errMsg = `Failed to load plant data.\n${error}`;
@@ -192,16 +194,25 @@ class PlantProfile extends Component {
       && <ListItem title={item.title} description={item.message} key={item.title} />);
 
     return (
-      <ScrollView style={{ flex: 1, width: '90%', marginLeft: '5%' }}>
-        {
-          !hideTitle
-          && (<Text category="h1">{plantData.plantName}</Text>)
-        }
-        <View style={{ width: '100%', minHeight: 250 }}>
-          <Image
-            source={{ uri: plantData.image.sourceURL }}
-            style={{
-              width: null, height: null, flex: 1, resizeMode: 'contain',
+      <ScrollView style={{
+        flex: 1,
+        width: '90%',
+        marginLeft: '5%',
+        marginTop: '15%',
+      }}
+      >
+        <View style={{ width: '100%', minHeight: 250, marginBottom: '5%' }}>
+          <CardItem
+            plant={plantData}
+            showNumOwned
+            onPressItem={() => {}}
+            styles={{
+              card: {
+                marginVertical: 0,
+              },
+              image: {
+                height: 250,
+              },
             }}
           />
         </View>
@@ -212,7 +223,9 @@ class PlantProfile extends Component {
             </Card>
           ) }
         <Divider />
-        {items}
+        <View style={{ marginBottom: '5%' }}>
+          {items}
+        </View>
       </ScrollView>
     );
   }
@@ -220,7 +233,6 @@ class PlantProfile extends Component {
 
 PlantProfile.propTypes = {
   plantID: PropTypes.string.isRequired,
-  hideTitle: PropTypes.bool.isRequired,
 };
 
 export default PlantProfile;


### PR DESCRIPTION
- Changed PlantProfile to use a CardItem, increasing usability.
- Changed CardItem to optionally show how many of the plant owned by the user.
- Fixed a bug in AddMyPlantDialog which caused an Error when adding a plant with no name/default.

Resolved #70 